### PR TITLE
Retard autothrottle on flare

### DIFF
--- a/Systems/afds-thrust.xml
+++ b/Systems/afds-thrust.xml
@@ -180,10 +180,16 @@
 		</enable>
 		<input>
 			<condition>
+				<and>
 				<equals>
 					<property>/it-autoflight/mode/thr</property>
 					<value>RETARD</value>
 				</equals>
+				<less-than>
+					<property>position/gear-agl-ft</property>
+					<value>25</value>
+				</less-than>
+				</and>
 			</condition>
 			<value>0.0</value>
 		</input>

--- a/Systems/afds-thrust.xml
+++ b/Systems/afds-thrust.xml
@@ -187,7 +187,7 @@
 				</equals>
 				<less-than>
 					<property>position/gear-agl-ft</property>
-					<value>25</value>
+					<value>27</value>
 				</less-than>
 				</and>
 			</condition>


### PR DESCRIPTION
Retard the auto thrust on 25 feet AGL to make it more realistic and easier to land