### PR TITLE
Disconnect autothrust at touchdown

### DIFF
--- a/Systems/afds-thrust.xml
+++ b/Systems/afds-thrust.xml
@@ -184,6 +184,10 @@
 					<property>/it-autoflight/mode/thr</property>
 					<value>RETARD</value>
 				</equals>
+				<equals>
+					<property>it-autoflight/custom/athr-armed</property>
+					<value>0</value>
+				</equals>	
 			</condition>
 			<value>0.0</value>
 		</input>


### PR DESCRIPTION
Disconnect the auto throttle on touchdown so after passing 25 feet it doesn't throttle to the selected speed again