### PR TITLE
Fix Reverse thrust animation in replay

### DIFF
--- a/Systems/flight-recorder.xml
+++ b/Systems/flight-recorder.xml
@@ -152,13 +152,13 @@
                 <type>float</type>
                 <property type="string">surface-positions/speedbrake-norm</property>
             </signal>
-            <signal>
-                <type>float</type>
-                <property type="string">surface-positions/reverser-norm[0]</property>
+	    <signal>
+                <type>double</type>
+                <property type="string">engines/engine/reverser-pos-norm</property>
             </signal>
             <signal>
-                <type>float</type>
-                <property type="string">surface-positions/reverser-norm[1]</property>
+                <type>double</type>
+                <property type="string">engines/engine[1]/reverser-pos-norm</property>
             </signal>
 			
            <signal>


### PR DESCRIPTION
Reverse thrust animation was not showing in replay because of incorrect configuration. Now fixed with correct property and such