### PR TITLE
Prevent reverse thrust unless below 10 ft agl

### DIFF
--- a/Nasal/reverse-thrust.nas
+++ b/Nasal/reverse-thrust.nas
@@ -6,9 +6,10 @@ r4 = "/controls/engines/engine[1]";
 r5 = "/sim/input/selected";
 rv1 = "/engines/engine[0]/reverser-pos-norm"; 
 rv2 = "/engines/engine[1]/reverser-pos-norm"; 
+var agl = getprop("/position/altitude-agl-ft");
 
 val = getprop(rv1);
-if (val == 0 or val == nil) {
+if (val == 0 or val == nil and agl < 10) {
 interpolate(rv1, 1.0, 1.4); 
 interpolate(rv2, 1.0, 1.4);  
 setprop(r1,"reverser-angle-rad","3.14159");


### PR DESCRIPTION
The 737NG allows reverse thrust to be activated under 10 ft agl