### PR TITLE
Added first-class and economy class views, and unified the indentation of 737-800YV-set.xml

### DIFF
--- a/737-800YV-set.xml
+++ b/737-800YV-set.xml
@@ -8,11 +8,11 @@
 
 		<aero>737-800YV</aero>
 		<startup>
-                        <splash-texture>Aircraft/737-800YV/Splash/splash-1.png</splash-texture>
-                        <splash-texture>Aircraft/737-800YV/Splash/splash-2.png</splash-texture>
-                        <splash-texture>Aircraft/737-800YV/Splash/splash-3.png</splash-texture>
-                        <splash-texture>Aircraft/737-800YV/Splash/splash-4.png</splash-texture>
-               </startup>
+			<splash-texture>Aircraft/737-800YV/Splash/splash-1.png</splash-texture>
+			<splash-texture>Aircraft/737-800YV/Splash/splash-2.png</splash-texture>
+			<splash-texture>Aircraft/737-800YV/Splash/splash-3.png</splash-texture>
+			<splash-texture>Aircraft/737-800YV/Splash/splash-4.png</splash-texture>
+		</startup>
 
 		<previews>
 			<preview>
@@ -140,7 +140,7 @@
 			</config>
 		</view>
 
-                <view n="103">
+		<view n="103">
 			<name>Right Wing</name>
 			<type>lookfrom</type>
 			<internal archive="y">true</internal>
@@ -155,8 +155,7 @@
 				<z-offset-m archive="y">2.19</z-offset-m>
 			</config>
 		</view>
-
-                <view n="104">
+		<view n="104">
 			<name>Left Wing</name>
 			<type>lookfrom</type>
 			<internal archive="y">true</internal>
@@ -172,7 +171,38 @@
 			</config>
 		</view>
 
-                <view n="105">
+		<view n="105">
+			<name>First Class</name>
+			<type>lookfrom</type>
+			<internal archive="y">true</internal>
+			<config>
+				<from-model type="bool">true</from-model>
+				<from-model-idx type="int">0</from-model-idx>
+				<default-field-of-view-deg type="double">80</default-field-of-view-deg>
+				<pitch-offset-deg>0</pitch-offset-deg>
+				<heading-offset-deg>90</heading-offset-deg>
+				<x-offset-m archive="y">0</x-offset-m>
+				<y-offset-m archive="y">1.60</y-offset-m>
+				<z-offset-m archive="y">-13.30</z-offset-m>
+			</config>
+		</view>
+		<view n="106">
+			<name>Economy Class</name>
+			<type>lookfrom</type>
+			<internal archive="y">true</internal>
+			<config>
+				<from-model type="bool">true</from-model>
+				<from-model-idx type="int">0</from-model-idx>
+				<default-field-of-view-deg type="double">80</default-field-of-view-deg>
+				<pitch-offset-deg>0</pitch-offset-deg>
+				<heading-offset-deg>90</heading-offset-deg>
+				<x-offset-m archive="y">0</x-offset-m>
+				<y-offset-m archive="y">1.60</y-offset-m>
+				<z-offset-m archive="y">-5.00</z-offset-m>
+			</config>
+		</view>
+
+		<view n="107">
 			<name>Overhead Panel</name>
 			<type>lookfrom</type>
 			<internal archive="y">true</internal>


### PR DESCRIPTION
Since the aircraft model does not have built-in first-class and economy-class view functions, and the walker cannot board the plane, I added first-class and economy-class views to the `737-800YV-set.xml` file.
<img width="1627" height="1023" alt="image" src="https://github.com/user-attachments/assets/32a3ed1e-cd45-45a3-87a0-950d30a3dfcd" />
<img width="1665" height="1041" alt="image" src="https://github.com/user-attachments/assets/40056454-1030-4c60-b0d6-11440c0e7df0" />
