### PR TITLE
Fix broken sound and model references

### DIFF
--- a/Models/Instruments/CDU/captain.xml
+++ b/Models/Instruments/CDU/captain.xml
@@ -1157,18 +1157,6 @@
 	</action>
 </animation>
 
-<animation>
-	<type>pick</type>
-	<object-name>Btn.nav-rad</object-name>
-	<action>
-		<button>0</button>
-		<repeatable>false</repeatable>
-		<binding>
-			<command>nasal</command>
-			<script>cdu.key(0, 'nav_rad');</script>
-		</binding>
-	</action>
-</animation>
 
 <animation>
 	<type>pick</type>

--- a/Models/Instruments/CDU/fo.xml
+++ b/Models/Instruments/CDU/fo.xml
@@ -1144,18 +1144,6 @@
 	</action>
 </animation>
 
-<animation>
-	<type>pick</type>
-	<object-name>Btn.nav-rad</object-name>
-	<action>
-		<button>0</button>
-		<repeatable>false</repeatable>
-		<binding>
-			<command>nasal</command>
-			<script>cdu.key(1, 'nav_rad');</script>
-		</binding>
-	</action>
-</animation>
 
 <animation>
 	<type>pick</type>

--- a/Models/cockpit.xml
+++ b/Models/cockpit.xml
@@ -2052,7 +2052,7 @@
 
 <model>
   <name>ldglightleftretr</name>
-  <path>landinglight.xml</path>
+  <path>lights/landinglight.xml</path>
   <offsets>
     <x-m>0.6127471</x-m>
     <y-m>-0.2644771</y-m>
@@ -2062,7 +2062,7 @@
 </model>
 <model>
   <name>ldglightrightretr</name>
-  <path>landinglight.xml</path>
+  <path>lights/landinglight.xml</path>
   <offsets>
     <x-m>0.6127595</x-m>
     <y-m>-0.1857275</y-m>
@@ -2072,7 +2072,7 @@
 </model>
 <model>
   <name>ldglightleftwing</name>
-  <path>landinglight.xml</path>
+  <path>lights/landinglight.xml</path>
   <offsets>
     <x-m>0.6121518</x-m>
     <y-m>-0.2147996</y-m>
@@ -2083,7 +2083,7 @@
 
 <model>
   <name>ldglightrightwing</name>
-  <path>landinglight.xml</path>
+  <path>lights/landinglight.xml</path>
   <offsets>
     <x-m>0.6134001</x-m>
     <y-m>-0.2420656</y-m>

--- a/Models/lights/landinglight.xml
+++ b/Models/lights/landinglight.xml
@@ -2,7 +2,7 @@
 
 <PropertyList>
 
-  <path>landing-light.ac</path>
+  <path>flash.ac</path>
 
   <animation>
     <!-- Objets opaques -->

--- a/Sounds/737-sound.xml
+++ b/Sounds/737-sound.xml
@@ -37,6 +37,9 @@
 		<name>a320_a1s</name>
 		<mode>looped</mode>
 		<path>FL2070/abn1strt.wav</path>
+
+		<property>fl2070/sound/a1strt</property>
+
 		<volume>
 			<property>fl2070/sound/a1strt</property>
 			<offset>0</offset>
@@ -46,16 +49,19 @@
 			<offset>0</offset>
 		</pitch>
 		<position>
-			<x>00</x>
+			<x>0</x>
 			<y>20</y>
-			<z>00</z>
+			<z>0</z>
 		</position>
 	</engine>
-	
+
 	<engine>
 		<name>a320_b1s</name>
 		<mode>looped</mode>
 		<path>FL2070/abn1strt.wav</path>
+
+		<property>fl2070/sound/b1strt</property>
+
 		<volume>
 			<property>fl2070/sound/b1strt</property>
 			<offset>0</offset>
@@ -65,9 +71,9 @@
 			<offset>0</offset>
 		</pitch>
 		<position>
-			<x>0.0</x>
+			<x>0</x>
 			<y>-20</y>
-			<z>0.0</z>
+			<z>0</z>
 		</position>
 	</engine>
 	


### PR DESCRIPTION
## Summary

Fixes several aircraft errors reported by FlightGear 2024.1.6:

- Add missing activation properties for engine-start sounds.
- Remove CDU pick animations referencing the nonexistent `Btn.nav-rad` object.
- Correct landing-light XML paths in `Models/cockpit.xml`.
- Load `flash.ac`, which contains the `flash` object expected by the landing-light animations.

## Testing

- Loaded the aircraft successfully in FlightGear 2024.1.6.
- Confirmed the related aircraft errors no longer appear.
- Validated edited XML files using `xmllint`.
- Ran `git diff --check` successfully.